### PR TITLE
⏱️ Replace preg_replace in tokenize with str_replace

### DIFF
--- a/src/Splashsky/Router.php
+++ b/src/Splashsky/Router.php
@@ -131,12 +131,12 @@ class Router
         $matches = $matches[1];
 
         foreach ($matches as $match) {
-            $pattern = "/(?:{".$match."})+/";
+            $pattern = '{'.$match.'}';
 
             if (in_array($match, $constraints)) {
-                $uri = preg_replace($pattern, '('.self::$constraints[$match].')', $uri);
+                $uri = str_replace($pattern, '('.self::$constraints[$match].')', $uri);
             } else {
-                $uri = preg_replace($pattern, self::$defaultConstraint, $uri);
+                $uri = str_replace($pattern, self::$defaultConstraint, $uri);
             }
         }
 


### PR DESCRIPTION
In some naive tests, `str_replace` can be up to 61% faster than `preg_replace` in simple operations. Given how `tokenize()` handles parameters, it made sense to do a simple refactor for the potential performance improvements in more-trafficked apps.

See [this article](https://www.simplemachines.org/community/index.php?topic=175031.0) for the naive tests mentioned.