### PR TITLE
🌊 Add prefix route group + fixes

### DIFF
--- a/src/Splashsky/Router.php
+++ b/src/Splashsky/Router.php
@@ -166,7 +166,10 @@ class Router
             $pattern = '{'.$match.'}';
 
             if (in_array($match, $constraints)) {
-                $uri = str_replace($pattern, '('.self::$constraints[$match].')', $uri);
+                // Do some voodoo to allow users to use parentheses in their constraints if they want
+                $constraint = '('.rtrim(ltrim(trim(self::$constraints[$match]), '('), ')').')';
+
+                $uri = str_replace($pattern, $constraint, $uri);
             } else {
                 $uri = str_replace($pattern, self::$defaultConstraint, $uri);
             }

--- a/src/Splashsky/Router.php
+++ b/src/Splashsky/Router.php
@@ -27,7 +27,7 @@ class Router
         }
 
         self::$routes[] = [
-            'route' => $route,
+            'route' => self::trimRoute($route),
             'action' => $action,
             'methods' => $methods
         ];
@@ -100,6 +100,12 @@ class Router
     public static function setDefaultConstraint(string $constraint = '([\w\-]+)')
     {
         self::$defaultConstraint = $constraint;
+    }
+
+    private static function trimRoute(string $route): string
+    {
+        $route = trim(trim($route), '/');
+        return "/$route";
     }
 
     /**
@@ -182,12 +188,7 @@ class Router
         $basePath = rtrim($basePath, '/');
         $method = $_SERVER['REQUEST_METHOD'];
         $uri = parse_url($_SERVER['REQUEST_URI'])['path'];
-        $path = urldecode(rtrim($uri, '/'));
-
-        // If the path is empty (no slash in URI) place one to satisfy the root route ('/')
-        if (empty($path)) {
-            $path = '/';
-        }
+        $path = urldecode(self::trimRoute($uri));
 
         $pathMatchFound = false;
         $routeMatchFound = false;

--- a/src/Splashsky/Router.php
+++ b/src/Splashsky/Router.php
@@ -188,7 +188,7 @@ class Router
      */
     public static function run(string $basePath = '', bool $multimatch = false)
     {
-        $basePath = rtrim($basePath, '/');
+        $basePath = self::trimRoute($basePath);
         $method = $_SERVER['REQUEST_METHOD'];
         $uri = parse_url($_SERVER['REQUEST_URI'])['path'];
         $path = urldecode(self::trimRoute($uri));
@@ -198,7 +198,8 @@ class Router
 
         // Begin looking through routes
         foreach (self::$routes as $route) {
-            if ($basePath != '' && $basePath != '/') {
+            // If the basePath isn't just "root"
+            if ($basePath != '/') {
                 $route['route'] = $basePath.$route['route'];
             }
         

--- a/src/Splashsky/Router.php
+++ b/src/Splashsky/Router.php
@@ -34,6 +34,7 @@ class Router
      *
      * @param string $route
      * @param callable $action
+     * @return Router
      */
     public static function get(string $route, callable $action)
     {
@@ -45,6 +46,7 @@ class Router
      *
      * @param string $route
      * @param callable $action
+     * @return Router
      */
     public static function post(string $route, callable $action)
     {
@@ -65,6 +67,7 @@ class Router
      * Defines an action to be called when a path isn't found - i.e. a 404
      *
      * @param callable $action
+     * @return void
      */
     public static function pathNotFound(callable $action)
     {
@@ -75,6 +78,7 @@ class Router
      * Defines an action to be called with a method isn't allowed on a route - i.e. a 405
      *
      * @param callable $action
+     * @return void
      */
     public static function methodNotAllowed(callable $action)
     {
@@ -149,6 +153,7 @@ class Router
      *
      * @param string $basePath
      * @param boolean $multimatch
+     * @return void
      */
     public static function run(string $basePath = '', bool $multimatch = false)
     {

--- a/src/Splashsky/Router.php
+++ b/src/Splashsky/Router.php
@@ -9,6 +9,7 @@ class Router
     private static $pathNotFound;
     private static $methodNotAllowed;
     private static string $defaultConstraint = '([\w\-]+)';
+    private static string $currentPrefix = '';
 
     /**
      * A quick static function to register a route in the router. Used by the shorthand methods as well.
@@ -20,6 +21,11 @@ class Router
      */
     public static function add(string $route, callable|string $action, string|array $methods = 'GET')
     {
+        // If a prefix exists, prepend it to the route
+        if (!empty(self::$currentPrefix)) {
+            $route = self::$currentPrefix.$route;
+        }
+
         self::$routes[] = [
             'route' => $route,
             'action' => $action,
@@ -94,6 +100,22 @@ class Router
     public static function setDefaultConstraint(string $constraint = '([\w\-]+)')
     {
         self::$defaultConstraint = $constraint;
+    }
+
+    /**
+     * Accepts a callable that defines routes, and adds a prefix to them.
+     *
+     * @param string $prefix The prefix you want added to the routes.
+     * @param callable $routes A function that defines routes.
+     * @return void
+     */
+    public static function prefix(string $prefix, callable $routes)
+    {
+        self::$currentPrefix = $prefix;
+
+        $routes();
+
+        self::$currentPrefix = '';
     }
 
     /**


### PR DESCRIPTION
👋🏻 Aloha!

Addressing #3, we needed some way of defining a group of routes that should all have a prefix and be separate from other routes. Thus, I am introducing... route grouping! ***yay!*** This update adds in a `prefix()` method to the Router that accepts a prefix and a callable that defines routes within. These routes will all have the given prefix prepended to them, allowing you to very easily group routes together.

```php
Router::prefix('/api', function () {
    Router::get('/test', function () {
        return 'Congratulations! Successful test!';
    });

    Router::get('/hello/{n}', function ($name) {
        return "Bonjour $name!";
    });

    Router::get('/age/{a}', function ($age) {
        return "I am $age";
    })->with('a', '[0-9]+');
});
```

Right now, though, don't try to nest prefix groups. This won't result in stacked prefixes, but instead the inner prefix will overwrite the outer prefix.

This update also handles #8 by doing a couple things - first I made a new `trimRoute()` method within the Router to trim routes and add a beginning forward slash consistently, so that routes follow a common structure. This means even if you pass `''` as a route, the Router will perceive it as `'/'`. This also means **all** routes have a beginning slash within the Router! I then applied this trim method to every place we were accepting a route or URI. This means behavior *should* be consistent in handling beginning slashes and empty routes.

Unfortunately, I also found #9 in this update, but that will be handled in a new branch with a new PR.